### PR TITLE
stop processing tx with amount == 0.0

### DIFF
--- a/service/elements_client.go
+++ b/service/elements_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 
 	elements "github.com/rddl-network/elements-rpc"
@@ -19,8 +20,9 @@ var (
 )
 
 func isValidAmount(amount string) (valid bool) {
+	amount = strings.TrimSpace(amount)
 	f, err := strconv.ParseFloat(amount, 64)
-	if err == nil && f != 0.0 {
+	if err == nil && f > 0.0 {
 		valid = true
 	}
 	return

--- a/service/elements_client.go
+++ b/service/elements_client.go
@@ -18,6 +18,14 @@ var (
 	elementsSyncAccess sync.Mutex
 )
 
+func isValidAmount(amount string) (valid bool) {
+	f, err := strconv.ParseFloat(amount, 64)
+	if err == nil && f != 0.0 {
+		valid = true
+	}
+	return
+}
+
 func (s *ShamirCoordinatorService) SendAsset(address string, amount string, asset string) (txID string, err error) {
 	if asset == "" {
 		asset = s.cfg.AssetID

--- a/service/router.go
+++ b/service/router.go
@@ -33,6 +33,12 @@ func (s *ShamirCoordinatorService) SendTokens(c *gin.Context) {
 		return
 	}
 	s.logger.Info("msg", "preparing to send "+request.Amount+" tokens to "+request.Recipient)
+	if !isValidAmount(request.Amount) {
+		msg := "Cannot send tokens with amount " + request.Amount
+		s.logger.Error("msg", msg)
+		c.JSON(http.StatusBadRequest, gin.H{"Error": msg})
+		return
+	}
 	passphrase, err := s.GetPassphrase()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})

--- a/service/router_test.go
+++ b/service/router_test.go
@@ -62,6 +62,21 @@ func TestSendPass(t *testing.T) {
 	assert.Equal(t, 200, w.Code)
 }
 
+func TestSendFailAmount0(t *testing.T) {
+	elements.Client = &elementsmocks.MockClient{}
+	s := testutil.SetupTestService(t)
+
+	request := types.SendTokensRequest{Amount: "0.0", Recipient: "1111111111111111111111111111"}
+	jsonString, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/send", bytes.NewBuffer(jsonString))
+	assert.NoError(t, err)
+	s.Router.ServeHTTP(w, req)
+	assert.Equal(t, 400, w.Code)
+}
+
 func TestSendFail(t *testing.T) {
 	elements.Client = &elementsmocks.MockClient{}
 	s := testutil.SetupTestService(t)

--- a/service/service.go
+++ b/service/service.go
@@ -131,6 +131,14 @@ func (s *ShamirCoordinatorService) rerunFailedRequests(waitPeriod int) {
 
 func (s *ShamirCoordinatorService) handleSendTokensRequest(req backend.SendTokensRequest) {
 	var keepInQueue = false
+	if !isValidAmount(req.Amount) {
+		s.logger.Info("msg", "Disregard token send request due to invalid amount "+req.Amount)
+		if err := s.db.DeleteRequest(backend.SendTokensRequestPrefix, req.ID); err != nil {
+			s.logger.Error("error", "failed to delete SendTokensRequest", "id", req.ID)
+		}
+		return
+	}
+
 	txID, err := s.SendAsset(req.Recipient, req.Amount, req.Asset)
 	if err != nil {
 		s.logger.Error("error", "error sending the transaction: "+err.Error())


### PR DESCRIPTION
Somehow, TX requests equal to 0.0 are sent in the testnet. 
This results in some issues with the elements service. That is why this fix was developed:

* stop sending and queuing tx with amount = 0.0
* Added test case

The root cause will also be fixed in another microservice and another PR.