### PR TITLE
fixed concurrency issues 

### DIFF
--- a/service/elements_client.go
+++ b/service/elements_client.go
@@ -18,7 +18,7 @@ var (
 	// so that UTXOs are not spend twice by accident
 	elementsSyncAccess sync.Mutex
 	lockingMutex       sync.Mutex
-	unlockCounter      int
+	unlockCounter      uint
 )
 
 func increaseUnlockCounter() {
@@ -30,7 +30,9 @@ func increaseUnlockCounter() {
 func decreaseUnlockCounter() (isZero bool) {
 	lockingMutex.Lock()
 	defer lockingMutex.Unlock()
-	unlockCounter--
+	if unlockCounter > 0 {
+		unlockCounter--
+	}
 	isZero = (unlockCounter == 0)
 	return
 }

--- a/service/elements_client_test.go
+++ b/service/elements_client_test.go
@@ -10,6 +10,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestLockingMutex(t *testing.T) {
+	elements.Client = &elementsmocks.MockClient{}
+	s := testutil.SetupTestService(t)
+
+	passphrase := "password"
+	err := s.PrepareWallet(passphrase)
+	assert.NoError(t, err)
+
+	err = s.PrepareWallet(passphrase)
+	assert.NoError(t, err)
+
+	locked, err := s.WalletLock()
+	assert.NoError(t, err)
+	assert.True(t, locked == false)
+
+	locked, err = s.WalletLock()
+	assert.NoError(t, err)
+	assert.True(t, locked == true)
+
+	err = s.PrepareWallet(passphrase)
+	assert.NoError(t, err)
+
+	locked, err = s.WalletLock()
+	assert.NoError(t, err)
+	assert.True(t, locked == true)
+}
+
 func TestSendTo(t *testing.T) {
 	elements.Client = &elementsmocks.MockClient{}
 	s := testutil.SetupTestService(t)

--- a/service/router.go
+++ b/service/router.go
@@ -69,7 +69,7 @@ func (s *ShamirCoordinatorService) SendTokens(c *gin.Context) {
 		c.JSON(http.StatusOK, resBody)
 	}
 
-	if err = s.WalletLock(); err != nil {
+	if _, err = s.WalletLock(); err != nil {
 		s.logger.Error("error", errWalletLockMsg+err.Error())
 	}
 }
@@ -109,7 +109,7 @@ func (s *ShamirCoordinatorService) ReIssue(c *gin.Context) {
 		c.JSON(http.StatusOK, types.ReIssueResponse{TxID: txID})
 	}
 
-	if err = s.WalletLock(); err != nil {
+	if _, err = s.WalletLock(); err != nil {
 		s.logger.Error("error", errWalletLockMsg+err.Error())
 	}
 }
@@ -153,7 +153,7 @@ func (s *ShamirCoordinatorService) IssueMachineNFT(c *gin.Context) {
 		})
 	}
 
-	if err = s.WalletLock(); err != nil {
+	if _, err = s.WalletLock(); err != nil {
 		s.logger.Error("error", errWalletLockMsg+err.Error())
 	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -123,7 +123,7 @@ func (s *ShamirCoordinatorService) rerunFailedRequests(waitPeriod int) {
 			s.handleIssueMachineNFTRequest(req)
 		}
 
-		if err = s.WalletLock(); err != nil {
+		if _, err = s.WalletLock(); err != nil {
 			s.logger.Error("error", errWalletLockMsg+err.Error())
 		}
 	}


### PR DESCRIPTION
fixed concurrency issues e.g. wallet locking even though multiple calls are concurrently in the sending/issuance function

* added a LockWallet mutex and counter (like semaphore)
* added test case
* changed Prepare Wallet to increase counter only in case of success
* changed LockWallet return params to support test cases