### PR TITLE
feat(config): add max-requests-per-rerun and update LoadConfig to han…

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The service needs to be configured via the ```./app.toml``` file or environment 
 asset-id = 'asset-id'
 certs-path = './certs/'
 log-level = 'info'
+max-requests-per-rerun = 15
 rpc-enc-timeout = 20
 rpc-host = 'localhost'
 rpc-password = 'password'
@@ -108,6 +109,7 @@ shamir-shares = 3
 shamir-threshold = 2
 share-holder-list = 'https://localhost:8081,https://localhost:8082,https://localhost:8083'
 test-mode = false
+wait-period = 300
 ```
 
 ## Database

--- a/cmd/dump-db/main.go
+++ b/cmd/dump-db/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -36,12 +37,12 @@ func formatKey(key []byte) string {
 			}
 		}
 	}
-	return fmt.Sprintf("%x", key)
+	return hex.EncodeToString(key)
 }
 
 func formatValue(val []byte) string {
 	if !isPrintable(val) {
-		return fmt.Sprintf("(binary) %x", val)
+		return "(binary) " + hex.EncodeToString(val)
 	}
 	// Try to pretty-print JSON
 	var js interface{}
@@ -55,6 +56,13 @@ func formatValue(val []byte) string {
 }
 
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	dbPath := "./data"
 	if len(os.Args) > 1 {
 		dbPath = os.Args[1]
@@ -62,8 +70,7 @@ func main() {
 
 	db, err := leveldb.OpenFile(dbPath, nil)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error opening LevelDB: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error opening LevelDB: %w", err)
 	}
 	defer db.Close()
 
@@ -90,8 +97,7 @@ func main() {
 	}
 
 	if err := iter.Error(); err != nil {
-		fmt.Fprintf(os.Stderr, "Iterator error: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("iterator error: %w", err)
 	}
 
 	if count == 0 {
@@ -102,8 +108,8 @@ func main() {
 
 	outputPath := "./data/db-dump.md"
 	if err := os.WriteFile(outputPath, []byte(sb.String()), 0600); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing output: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error writing output: %w", err)
 	}
 	fmt.Printf("Wrote %d entries to %s\n", count, outputPath)
+	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -24,28 +24,30 @@ test-mode={{ .TestMode }}
 log-level="{{ .LogLevel }}"
 db-path="{{ .DBPath }}"
 wait-period={{ .WaitPeriod }}
+max-requests-per-rerun={{ .MaxRequestsPerRerun }}
 `
 
 // Config defines TA's top level configuration
 type Config struct {
-	ServiceBind     string `json:"service-bind"      mapstructure:"service-bind"`
-	ServicePort     int    `json:"service-port"      mapstructure:"service-port"`
-	ShareHolderList string `json:"share-holder-list" mapstructure:"share-holder-list"`
-	CertsPath       string `json:"certs-path"        mapstructure:"certs-path"`
-	RPCWalletName   string `json:"rpc-wallet-name"   mapstructure:"rpc-wallet-name"`
-	RPCHost         string `json:"rpc-host"          mapstructure:"rpc-host"`
-	RPCPort         int    `json:"rpc-port"          mapstructure:"pc-port"`
-	RPCUser         string `json:"rpc-user"          mapstructure:"rpc-user"`
-	RPCPassword     string `json:"rpc-password"      mapstructure:"rpc-password"`
-	RPCScheme       string `json:"rpc-scheme"        mapstructure:"rpc-scheme"`
-	RPCEncTimeout   int    `json:"rpc-enc-timeout"   mapstructure:"rpc-enc-timeout"`
-	AssetID         string `json:"asset-id"          mapstructure:"asset-id"`
-	ShamirThreshold int    `json:"shamir-threshold"  mapstructure:"shamir-threshold"`
-	ShamirShares    int    `json:"shamir-shares"     mapstructure:"shamir-shares"`
-	TestMode        bool   `json:"test-mode"         mapstructure:"test-mode"`
-	LogLevel        string `json:"log-level"         mapstructure:"log-level"`
-	DBPath          string `json:"db-path"           mapstructure:"db-path"`
-	WaitPeriod      int    `json:"wait-period"       mapstructure:"wait-period"`
+	ServiceBind         string `json:"service-bind"      mapstructure:"service-bind"`
+	ServicePort         int    `json:"service-port"      mapstructure:"service-port"`
+	ShareHolderList     string `json:"share-holder-list" mapstructure:"share-holder-list"`
+	CertsPath           string `json:"certs-path"        mapstructure:"certs-path"`
+	RPCWalletName       string `json:"rpc-wallet-name"   mapstructure:"rpc-wallet-name"`
+	RPCHost             string `json:"rpc-host"          mapstructure:"rpc-host"`
+	RPCPort             int    `json:"rpc-port"          mapstructure:"pc-port"`
+	RPCUser             string `json:"rpc-user"          mapstructure:"rpc-user"`
+	RPCPassword         string `json:"rpc-password"      mapstructure:"rpc-password"`
+	RPCScheme           string `json:"rpc-scheme"        mapstructure:"rpc-scheme"`
+	RPCEncTimeout       int    `json:"rpc-enc-timeout"   mapstructure:"rpc-enc-timeout"`
+	AssetID             string `json:"asset-id"          mapstructure:"asset-id"`
+	ShamirThreshold     int    `json:"shamir-threshold"  mapstructure:"shamir-threshold"`
+	ShamirShares        int    `json:"shamir-shares"     mapstructure:"shamir-shares"`
+	TestMode            bool   `json:"test-mode"         mapstructure:"test-mode"`
+	LogLevel            string `json:"log-level"         mapstructure:"log-level"`
+	DBPath              string `json:"db-path"           mapstructure:"db-path"`
+	WaitPeriod          int    `json:"wait-period"       mapstructure:"wait-period"`
+	MaxRequestsPerRerun int    `json:"max-requests-per-rerun" mapstructure:"max-requests-per-rerun"`
 }
 
 // global singleton
@@ -57,24 +59,25 @@ var (
 // DefaultConfig returns TA's default configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		ServiceBind:     "localhost",
-		ServicePort:     8080,
-		ShareHolderList: "https://localhost:8081,https://localhost:8082,https://localhost:8083",
-		CertsPath:       "./certs/",
-		RPCWalletName:   "wallet",
-		RPCHost:         "localhost",
-		RPCPort:         18884,
-		RPCUser:         "user",
-		RPCPassword:     "password",
-		RPCScheme:       "http",
-		RPCEncTimeout:   20,
-		AssetID:         "asset-id",
-		ShamirThreshold: 2,
-		ShamirShares:    3,
-		TestMode:        false,
-		LogLevel:        "info",
-		DBPath:          "./data/",
-		WaitPeriod:      300,
+		ServiceBind:         "localhost",
+		ServicePort:         8080,
+		ShareHolderList:     "https://localhost:8081,https://localhost:8082,https://localhost:8083",
+		CertsPath:           "./certs/",
+		RPCWalletName:       "wallet",
+		RPCHost:             "localhost",
+		RPCPort:             18884,
+		RPCUser:             "user",
+		RPCPassword:         "password",
+		RPCScheme:           "http",
+		RPCEncTimeout:       20,
+		AssetID:             "asset-id",
+		ShamirThreshold:     2,
+		ShamirShares:        3,
+		TestMode:            false,
+		LogLevel:            "info",
+		DBPath:              "./data/",
+		WaitPeriod:          300,
+		MaxRequestsPerRerun: 15,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -29,24 +29,24 @@ max-requests-per-rerun={{ .MaxRequestsPerRerun }}
 
 // Config defines TA's top level configuration
 type Config struct {
-	ServiceBind         string `json:"service-bind"      mapstructure:"service-bind"`
-	ServicePort         int    `json:"service-port"      mapstructure:"service-port"`
-	ShareHolderList     string `json:"share-holder-list" mapstructure:"share-holder-list"`
-	CertsPath           string `json:"certs-path"        mapstructure:"certs-path"`
-	RPCWalletName       string `json:"rpc-wallet-name"   mapstructure:"rpc-wallet-name"`
-	RPCHost             string `json:"rpc-host"          mapstructure:"rpc-host"`
-	RPCPort             int    `json:"rpc-port"          mapstructure:"pc-port"`
-	RPCUser             string `json:"rpc-user"          mapstructure:"rpc-user"`
-	RPCPassword         string `json:"rpc-password"      mapstructure:"rpc-password"`
-	RPCScheme           string `json:"rpc-scheme"        mapstructure:"rpc-scheme"`
-	RPCEncTimeout       int    `json:"rpc-enc-timeout"   mapstructure:"rpc-enc-timeout"`
-	AssetID             string `json:"asset-id"          mapstructure:"asset-id"`
-	ShamirThreshold     int    `json:"shamir-threshold"  mapstructure:"shamir-threshold"`
-	ShamirShares        int    `json:"shamir-shares"     mapstructure:"shamir-shares"`
-	TestMode            bool   `json:"test-mode"         mapstructure:"test-mode"`
-	LogLevel            string `json:"log-level"         mapstructure:"log-level"`
-	DBPath              string `json:"db-path"           mapstructure:"db-path"`
-	WaitPeriod          int    `json:"wait-period"       mapstructure:"wait-period"`
+	ServiceBind         string `json:"service-bind"           mapstructure:"service-bind"`
+	ServicePort         int    `json:"service-port"           mapstructure:"service-port"`
+	ShareHolderList     string `json:"share-holder-list"      mapstructure:"share-holder-list"`
+	CertsPath           string `json:"certs-path"             mapstructure:"certs-path"`
+	RPCWalletName       string `json:"rpc-wallet-name"        mapstructure:"rpc-wallet-name"`
+	RPCHost             string `json:"rpc-host"               mapstructure:"rpc-host"`
+	RPCPort             int    `json:"rpc-port"               mapstructure:"pc-port"`
+	RPCUser             string `json:"rpc-user"               mapstructure:"rpc-user"`
+	RPCPassword         string `json:"rpc-password"           mapstructure:"rpc-password"`
+	RPCScheme           string `json:"rpc-scheme"             mapstructure:"rpc-scheme"`
+	RPCEncTimeout       int    `json:"rpc-enc-timeout"        mapstructure:"rpc-enc-timeout"`
+	AssetID             string `json:"asset-id"               mapstructure:"asset-id"`
+	ShamirThreshold     int    `json:"shamir-threshold"       mapstructure:"shamir-threshold"`
+	ShamirShares        int    `json:"shamir-shares"          mapstructure:"shamir-shares"`
+	TestMode            bool   `json:"test-mode"              mapstructure:"test-mode"`
+	LogLevel            string `json:"log-level"              mapstructure:"log-level"`
+	DBPath              string `json:"db-path"                mapstructure:"db-path"`
+	WaitPeriod          int    `json:"wait-period"            mapstructure:"wait-period"`
 	MaxRequestsPerRerun int    `json:"max-requests-per-rerun" mapstructure:"max-requests-per-rerun"`
 }
 

--- a/config/util.go
+++ b/config/util.go
@@ -36,6 +36,12 @@ func LoadConfig(path string) (cfg *Config, err error) {
 		cfg.TestMode = v.GetBool("test-mode")
 		cfg.LogLevel = v.GetString("log-level")
 		cfg.DBPath = v.GetString("db-path")
+		if v.IsSet("wait-period") {
+			cfg.WaitPeriod = v.GetInt("wait-period")
+		}
+		if v.IsSet("max-requests-per-rerun") {
+			cfg.MaxRequestsPerRerun = v.GetInt("max-requests-per-rerun")
+		}
 
 		if err := viper.Unmarshal(&cfg); err != nil {
 			log.Fatal(err)

--- a/service/service.go
+++ b/service/service.go
@@ -79,70 +79,84 @@ func (s *ShamirCoordinatorService) rerunFailedRequests(waitPeriod int, maxReques
 	}
 
 	for range ticker.C {
-		sendTokensRequests, err := s.db.GetAllSendTokensRequests()
-		if err != nil {
-			s.logger.Error("msg", "error while reading sendTokensRequests: "+err.Error())
-		}
-
-		reIssueRequests, err := s.db.GetAllReissueRequests()
-		if err != nil {
-			s.logger.Error("msg", "error while reading reIssueRequests: "+err.Error())
-		}
-
-		issueNFTAssetRequests, err := s.db.GetAllIssueMachineNFTRequests()
-		if err != nil {
-			s.logger.Error("msg", "error while reading issueNFTAssetRequests: "+err.Error())
-		}
-
-		numReqs := len(sendTokensRequests) + len(reIssueRequests) + len(issueNFTAssetRequests)
-
-		// If no reqs are read from backend do not unlock wallet
-		if numReqs == 0 {
+		sendTokensRequests, reIssueRequests, issueNFTAssetRequests := s.readQueuedRequests()
+		if len(sendTokensRequests)+len(reIssueRequests)+len(issueNFTAssetRequests) == 0 {
 			continue
 		}
 
-		passphrase, err := s.GetPassphrase()
-		if err != nil {
-			s.logger.Error("error", errWalletMsg+err.Error())
+		if !s.prepareWalletForRerun() {
 			continue
 		}
 
-		// prepare the wallet, loading and unlocking
-		err = s.PrepareWallet(passphrase)
-		if err != nil {
-			s.logger.Error("error", errWalletMsg+err.Error())
-			continue
-		}
+		s.processQueuedRequests(sendTokensRequests, reIssueRequests, issueNFTAssetRequests, maxRequestsPerRerun)
 
-		remaining := maxRequestsPerRerun
-
-		for _, req := range sendTokensRequests {
-			if remaining == 0 {
-				break
-			}
-			s.handleSendTokensRequest(req)
-			remaining--
+		if _, walletLockErr := s.WalletLock(); walletLockErr != nil {
+			s.logger.Error("error", errWalletLockMsg+walletLockErr.Error())
 		}
+	}
+}
 
-		for _, req := range reIssueRequests {
-			if remaining == 0 {
-				break
-			}
-			s.handleReIssueRequest(req)
-			remaining--
-		}
+func (s *ShamirCoordinatorService) readQueuedRequests() ([]backend.SendTokensRequest, []backend.ReIssueRequest, []backend.IssueMachineNFTRequest) {
+	sendTokensRequests, err := s.db.GetAllSendTokensRequests()
+	if err != nil {
+		s.logger.Error("msg", "error while reading sendTokensRequests: "+err.Error())
+	}
 
-		for _, req := range issueNFTAssetRequests {
-			if remaining == 0 {
-				break
-			}
-			s.handleIssueMachineNFTRequest(req)
-			remaining--
-		}
+	reIssueRequests, err := s.db.GetAllReissueRequests()
+	if err != nil {
+		s.logger.Error("msg", "error while reading reIssueRequests: "+err.Error())
+	}
 
-		if _, err = s.WalletLock(); err != nil {
-			s.logger.Error("error", errWalletLockMsg+err.Error())
+	issueNFTAssetRequests, err := s.db.GetAllIssueMachineNFTRequests()
+	if err != nil {
+		s.logger.Error("msg", "error while reading issueNFTAssetRequests: "+err.Error())
+	}
+
+	return sendTokensRequests, reIssueRequests, issueNFTAssetRequests
+}
+
+func (s *ShamirCoordinatorService) prepareWalletForRerun() bool {
+	passphrase, err := s.GetPassphrase()
+	if err != nil {
+		s.logger.Error("error", errWalletMsg+err.Error())
+		return false
+	}
+
+	// prepare the wallet, loading and unlocking
+	err = s.PrepareWallet(passphrase)
+	if err != nil {
+		s.logger.Error("error", errWalletMsg+err.Error())
+		return false
+	}
+
+	return true
+}
+
+func (s *ShamirCoordinatorService) processQueuedRequests(sendTokensRequests []backend.SendTokensRequest, reIssueRequests []backend.ReIssueRequest, issueNFTAssetRequests []backend.IssueMachineNFTRequest, maxRequestsPerRerun int) {
+	remaining := maxRequestsPerRerun
+
+	for _, req := range sendTokensRequests {
+		if remaining == 0 {
+			return
 		}
+		s.handleSendTokensRequest(req)
+		remaining--
+	}
+
+	for _, req := range reIssueRequests {
+		if remaining == 0 {
+			return
+		}
+		s.handleReIssueRequest(req)
+		remaining--
+	}
+
+	for _, req := range issueNFTAssetRequests {
+		if remaining == 0 {
+			return
+		}
+		s.handleIssueMachineNFTRequest(req)
+		remaining--
 	}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -66,14 +66,17 @@ func (s *ShamirCoordinatorService) Run() (err error) {
 		return err
 	}
 	defer ln.Close()
-	go s.rerunFailedRequests(cfg.WaitPeriod)
+	go s.rerunFailedRequests(cfg.WaitPeriod, cfg.MaxRequestsPerRerun)
 	s.logger.Info("msg", "started server", "host", cfg.ServiceBind, "port", cfg.ServicePort)
 	return server.ServeTLS(ln, cfg.CertsPath+"server.crt", cfg.CertsPath+"server.key")
 }
 
-func (s *ShamirCoordinatorService) rerunFailedRequests(waitPeriod int) {
+func (s *ShamirCoordinatorService) rerunFailedRequests(waitPeriod int, maxRequestsPerRerun int) {
 	ticker := time.NewTicker(time.Duration(waitPeriod) * time.Second)
 	defer ticker.Stop()
+	if maxRequestsPerRerun <= 0 {
+		maxRequestsPerRerun = 15
+	}
 
 	for range ticker.C {
 		sendTokensRequests, err := s.db.GetAllSendTokensRequests()
@@ -111,16 +114,30 @@ func (s *ShamirCoordinatorService) rerunFailedRequests(waitPeriod int) {
 			continue
 		}
 
+		remaining := maxRequestsPerRerun
+
 		for _, req := range sendTokensRequests {
+			if remaining == 0 {
+				break
+			}
 			s.handleSendTokensRequest(req)
+			remaining--
 		}
 
 		for _, req := range reIssueRequests {
+			if remaining == 0 {
+				break
+			}
 			s.handleReIssueRequest(req)
+			remaining--
 		}
 
 		for _, req := range issueNFTAssetRequests {
+			if remaining == 0 {
+				break
+			}
 			s.handleIssueMachineNFTRequest(req)
+			remaining--
 		}
 
 		if _, err = s.WalletLock(); err != nil {


### PR DESCRIPTION
…dle new parameters
This pull request introduces a configurable limit on the number of failed requests retried per rerun cycle in the Shamir Coordinator Service. The main goal is to prevent the system from being overloaded by too many retries in a single cycle. The changes add a new configuration option, `max-requests-per-rerun`, and update the service logic to enforce this limit.

**Configuration improvements:**

* Added `max-requests-per-rerun` option to the configuration files (`app.toml`, `README.md`, `config.go`) with a default value of 15, allowing users to control how many failed requests are retried per cycle. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R27) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R50) [[4]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R80)
* Updated the configuration loader to read `max-requests-per-rerun` from the config file or environment, ensuring the value is correctly set at runtime.

**Service logic updates:**

* Modified the `rerunFailedRequests` method in `service.go` to accept and enforce the `max-requests-per-rerun` limit, applying it across all types of failed requests (send tokens, re-issue, and issue NFT asset requests). [[1]](diffhunk://#diff-85ee04e67bda04e6159b92426c87fe161c58d4b5550ef2b0fa7a97214309c125L69-R79) [[2]](diffhunk://#diff-85ee04e67bda04e6159b92426c87fe161c58d4b5550ef2b0fa7a97214309c125R117-R140)

**Documentation:**

* Updated the `README.md` to document the new `max-requests-per-rerun` option and its usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R112)